### PR TITLE
Add .github/workflows to Renovate includePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,8 @@
   },
   "includePaths": [
     "package.json",
-    "package-lock.json"
+    "package-lock.json",
+    ".github/workflows/**"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/**` to the Renovate `includePaths` configuration
- This enables Renovate to scan GitHub Actions workflows for dependency updates, which was previously blocked by the `includePaths` configuration despite having `github-actions` enabled

## Test plan
- Renovate will now include GitHub Actions workflows in its scans and propose PRs for action version updates