### PR TITLE
Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.5.3 (Unreleased)
+## 0.5.3 (2026-04-09)
 
 ### Fixed
 - **Config manager**: `getCraftDeskJson()` now accepts an optional `cwd` parameter so multi-agent sync, verify, and gitignore operations read config from the correct directory instead of always using `process.cwd()` [#67 review](https://github.com/mensfeld/craftdesk/pull/67#pullrequestreview-3909525763)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "craftdesk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "craftdesk",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "craftdesk",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Package manager for Claude Code skills, agents, commands, hooks, and plugins",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Bumps version to **0.5.3** and finalizes the CHANGELOG date
- Ships two bug fixes since 0.5.2:
  - **Config manager**: `getCraftDeskJson()` now accepts an optional `cwd` parameter so multi-agent sync, verify, and gitignore operations read config from the correct directory instead of always using `process.cwd()` (#69)
  - **Sync gitignore**: Embedded (local) skills are now gitignored in target directories (`.agents/skills/`, `.cursor/skills/`, etc.) to prevent duplicate copies being committed — only the canonical `.claude/skills/` tracks them (#80, closes #72)

See [CHANGELOG.md](https://github.com/mensfeld/craftdesk/blob/release/0.5.3/CHANGELOG.md#053-2026-04-09) for the full entry.

## Test plan
- [x] `npm run build` succeeds
- [x] CLI version matches `package.json` (`craftdesk --version` → `0.5.3`)
- [ ] CI passes (tests, type-check, lint, build, version consistency)
- [ ] After merge: tag `v0.5.3` and create GitHub release to trigger NPM publish workflow